### PR TITLE
generated action types and reducer for sernos config

### DIFF
--- a/src/Service.Host/client/src/actions/index.js
+++ b/src/Service.Host/client/src/actions/index.js
@@ -17,3 +17,17 @@ export const REQUEST_CARTON_TYPE = 'REQUEST_CARTON_TYPE';
 export const RECEIVE_CARTON_TYPE = 'RECEIVE_CARTON_TYPE';
 export const RECEIVE_NEW_CARTON_TYPE = 'RECEIVE_NEW_CARTON_TYPE';
 export const RESET_CARTON_TYPE = 'RESET_CARTON_TYPE';
+
+const makeActionTypes = (entityType) => {
+    var types = {};
+    types['REQUEST_'.concat(entityType)] = 'REQUEST_'.concat(entityType);
+    types['REQUEST_ADD_'.concat(entityType)] = 'REQUEST_ADD_'.concat(entityType);
+    types['REQUEST_UPDATE_'.concat(entityType)] = 'REQUEST_UPDATE_'.concat(entityType);
+    types['RESET_'.concat(entityType)] = 'RESET_'.concat(entityType);
+    types['RECEIVE_'.concat(entityType)] = 'RECEIVE_'.concat(entityType);
+    types['RECEIVE_NEW_'.concat(entityType)] = 'RECEIVE_NEW_'.concat(entityType);
+
+    return types;
+}
+
+export const sernosConfigActionTypes = makeActionTypes('SERNOS_CONFIG');

--- a/src/Service.Host/client/src/actions/index.js
+++ b/src/Service.Host/client/src/actions/index.js
@@ -20,12 +20,12 @@ export const RESET_CARTON_TYPE = 'RESET_CARTON_TYPE';
 
 const makeActionTypes = (entityType) => {
     var types = {};
-    types['REQUEST_'.concat(entityType)] = 'REQUEST_'.concat(entityType);
-    types['REQUEST_ADD_'.concat(entityType)] = 'REQUEST_ADD_'.concat(entityType);
-    types['REQUEST_UPDATE_'.concat(entityType)] = 'REQUEST_UPDATE_'.concat(entityType);
-    types['RESET_'.concat(entityType)] = 'RESET_'.concat(entityType);
-    types['RECEIVE_'.concat(entityType)] = 'RECEIVE_'.concat(entityType);
-    types['RECEIVE_NEW_'.concat(entityType)] = 'RECEIVE_NEW_'.concat(entityType);
+    types[`REQUEST_${entityType}`] = `REQUEST_${entityType}`;
+    types[`REQUEST_ADD_${entityType}`] = `REQUEST_ADD_${entityType}`;
+    types[`REQUEST_UPDATE_${entityType}`] = `REQUEST_UPDATE_${entityType}`;
+    types[`RESET_${entityType}`] = `RESET_${entityType}`;
+    types[`RECEIVE_${entityType}`] = `RECEIVE_${entityType}`;
+    types[`RECEIVE_NEW_${entityType}`] = `RECEIVE_NEW_${entityType}`;
 
     return types;
 }

--- a/src/Service.Host/client/src/reducers/__tests__/itemStoreFactory.js
+++ b/src/Service.Host/client/src/reducers/__tests__/itemStoreFactory.js
@@ -1,0 +1,145 @@
+﻿import itemStoreFactory from '../reducerFactories/itemStoreFactory';
+import deepFreeze from 'deep-freeze';
+
+describe('item store reducer factory', () => {
+    const actionTypes = {
+        REQUEST_ENTITY: 'REQUEST_ENTITY',
+        RESET_ENTITY: 'RESET_ENTITY',
+        REQUEST_UPDATE_ENTITY: 'REQUEST_UPDATE_ENTITY',
+        REQUEST_ADD_ENTITY: 'REQUEST_ADD_ENTITY',
+        RECEIVE_ENTITY: 'RECEIVE_ENTITY',
+        RECEIVE_NEW_ENTITY: 'RECEIVE_NEW_ENTITY'
+    };
+    const defaultState = {
+        loading: false,
+        item: null,
+        editStatus: 'view'
+    };
+    const generatedReducer = itemStoreFactory('ENTITY', actionTypes, defaultState);
+
+    test('when requesting entity', () => {
+        const state = {
+            loading: false
+        };
+
+        const action = {
+            type: actionTypes.REQUEST_ENTITY,
+            payload: {}
+        };
+
+        const expected = {
+            loading: true,
+            editStatus: 'view'
+        };
+
+        deepFreeze(state);
+
+        expect(generatedReducer(state, action)).toEqual(expected);
+    });
+
+    test('when resetting entity', () => {
+        const state = {
+            loading: false, 
+            item: { name: 'name'}
+        };
+
+        const action = {
+            type: actionTypes.RESET_ENTITY,
+            payload: {}
+        };
+
+        const expected = {
+            loading: false,
+            item: { name: 'name' },
+            editStatus: 'view'
+        };
+
+        deepFreeze(state);
+
+        expect(generatedReducer(state, action)).toEqual(expected);
+    });
+
+    test('when requesting update entity', () => {
+        const state = {
+            loading: false
+        };
+
+        const action = {
+            type: actionTypes.REQUEST_UPDATE_ENTITY,
+            payload: {}
+        };
+
+        const expected = {
+            loading: false,
+            editStatus: 'edit'
+        };
+
+        deepFreeze(state);
+
+        expect(generatedReducer(state, action)).toEqual(expected);
+    });
+
+    test('when requesting add entity', () => {
+        const state = {
+            loading: false
+        };
+
+        const action = {
+            type: actionTypes.REQUEST_ADD_ENTITY,
+            payload: {}
+        };
+
+        const expected = {
+            loading: true,
+            editStatus: 'create'
+        };
+
+        deepFreeze(state);
+
+        expect(generatedReducer(state, action)).toEqual(expected);
+    });
+
+    test('when receiving entity', () => {
+        const state = {
+            loading: true,
+            item: null
+        };
+
+        const action = {
+            type: actionTypes.RECEIVE_ENTITY,
+            payload: { data: { name: '1' } }
+        };
+
+        const expected = {
+            loading: false,
+            item: { name: '1' },
+            editStatus: 'view'
+        };
+
+        deepFreeze(state);
+
+        expect(generatedReducer(state, action)).toEqual(expected);
+    });
+
+    test('when receiving new entity', () => {
+        const state = {
+            loading: true,
+            item: null
+        };
+
+        const action = {
+            type: actionTypes.RECEIVE_NEW_ENTITY,
+            payload: { data: { name: '1' } }
+        };
+
+        const expected = {
+            loading: false,
+            item: { name: '1' },
+            editStatus: 'view'
+        };
+
+        deepFreeze(state);
+
+        expect(generatedReducer(state, action)).toEqual(expected);
+    });
+});

--- a/src/Service.Host/client/src/reducers/__tests__/sernosConfig.js
+++ b/src/Service.Host/client/src/reducers/__tests__/sernosConfig.js
@@ -1,0 +1,132 @@
+﻿import sernosConfig from '../sernosConfig';
+import deepFreeze from 'deep-freeze';
+import { sernosConfigActionTypes as actionTypes } from '../../actions';
+
+describe('sernos config reducer', () => {
+
+    test('when requesting sernos config', () => {
+        const state = {
+            loading: false
+        };
+
+        const action = {
+            type: actionTypes.REQUEST_SERNOS_CONFIG,
+            payload: {}
+        };
+
+        const expected = {
+            loading: true,
+            editStatus: 'view'
+        };
+
+        deepFreeze(state);
+
+        expect(sernosConfig(state, action)).toEqual(expected);
+    });
+
+    test('when resetting sernos config', () => {
+        const state = {
+            loading: false, 
+            item: { name: 'name'}
+        };
+
+        const action = {
+            type: actionTypes.RESET_SERNOS_CONFIG,
+            payload: {}
+        };
+
+        const expected = {
+            loading: false,
+            item: { name: 'name' },
+            editStatus: 'view'
+        };
+
+        deepFreeze(state);
+
+        expect(sernosConfig(state, action)).toEqual(expected);
+    });
+
+    test('when requesting update sernos config', () => {
+        const state = {
+            loading: false
+        };
+
+        const action = {
+            type: actionTypes.REQUEST_UPDATE_SERNOS_CONFIG,
+            payload: {}
+        };
+
+        const expected = {
+            loading: false,
+            editStatus: 'edit'
+        };
+
+        deepFreeze(state);
+
+        expect(sernosConfig(state, action)).toEqual(expected);
+    });
+
+    test('when requesting add sernos config', () => {
+        const state = {
+            loading: false
+        };
+
+        const action = {
+            type: actionTypes.REQUEST_ADD_SERNOS_CONFIG,
+            payload: {}
+        };
+
+        const expected = {
+            loading: true,
+            editStatus: 'create'
+        };
+
+        deepFreeze(state);
+
+        expect(sernosConfig(state, action)).toEqual(expected);
+    });
+
+    test('when receiving sernos config', () => {
+        const state = {
+            loading: true,
+            item: null
+        };
+
+        const action = {
+            type: actionTypes.RECEIVE_SERNOS_CONFIG,
+            payload: { data: { name: '1' } }
+        };
+
+        const expected = {
+            loading: false,
+            item: { name: '1' },
+            editStatus: 'view'
+        };
+
+        deepFreeze(state);
+
+        expect(sernosConfig(state, action)).toEqual(expected);
+    });
+
+    test('when receiving new sernos config', () => {
+        const state = {
+            loading: true,
+            item: null
+        };
+
+        const action = {
+            type: actionTypes.RECEIVE_NEW_SERNOS_CONFIG,
+            payload: { data: { name: '1' } }
+        };
+
+        const expected = {
+            loading: false,
+            item: { name: '1' },
+            editStatus: 'view'
+        };
+
+        deepFreeze(state);
+
+        expect(sernosConfig(state, action)).toEqual(expected);
+    });
+});

--- a/src/Service.Host/client/src/reducers/index.js
+++ b/src/Service.Host/client/src/reducers/index.js
@@ -5,6 +5,7 @@ import cartonDetailsReport from './cartonDetailsReport';
 import productRangesReport from './productRangesReport';
 import salesProductsByProductRangeReport from './salesProductsByProductRangeReport';
 import cartonType from './cartonType';
+import sernosConfig from './sernosConfig';
 import fetchError from './fetchError';
 
 const rootReducer = combineReducers({
@@ -14,6 +15,7 @@ const rootReducer = combineReducers({
     productRangesReport,
     salesProductsByProductRangeReport,
     cartonType,
+    sernosConfig,
     fetchError
 });
 

--- a/src/Service.Host/client/src/reducers/reducerFactories/itemStoreFactory.js
+++ b/src/Service.Host/client/src/reducers/reducerFactories/itemStoreFactory.js
@@ -1,0 +1,42 @@
+﻿export default function (itemRoot, actionTypes, defaultState = { loading: false, item: null, editStatus: 'view' })
+{
+    return (state = defaultState, action) => {
+        switch (action.type) {
+        case actionTypes['REQUEST_ADD_'.concat(itemRoot)]:
+            return {
+                ...state,
+                loading: true,
+                editStatus: 'create'
+            }
+        case actionTypes['REQUEST_'.concat(itemRoot)]:
+            return {
+                ...state,
+                loading: true,
+                editStatus: 'view'
+            }
+
+        case actionTypes['REQUEST_UPDATE_'.concat(itemRoot)]:
+            return {
+                ...state,
+                editStatus: 'edit'
+            }
+
+        case actionTypes['RESET_'.concat(itemRoot)]:
+            return {
+                ...state,
+                editStatus: 'view'
+            }
+
+        case actionTypes['RECEIVE_'.concat(itemRoot)]:
+            case actionTypes['RECEIVE_NEW_'.concat(itemRoot)]:
+            return {
+                ...state,
+                loading: false,
+                item: action.payload.data,
+                editStatus: 'view'
+            }
+        }
+
+        return state;
+    }
+}

--- a/src/Service.Host/client/src/reducers/reducerFactories/itemStoreFactory.js
+++ b/src/Service.Host/client/src/reducers/reducerFactories/itemStoreFactory.js
@@ -2,33 +2,33 @@
 {
     return (state = defaultState, action) => {
         switch (action.type) {
-        case actionTypes['REQUEST_ADD_'.concat(itemRoot)]:
+        case actionTypes[`REQUEST_ADD_${itemRoot}`]:
             return {
                 ...state,
                 loading: true,
                 editStatus: 'create'
             }
-        case actionTypes['REQUEST_'.concat(itemRoot)]:
+        case actionTypes[`REQUEST_${itemRoot}`]:
             return {
                 ...state,
                 loading: true,
                 editStatus: 'view'
             }
 
-        case actionTypes['REQUEST_UPDATE_'.concat(itemRoot)]:
+        case actionTypes[`REQUEST_UPDATE_${itemRoot}`]:
             return {
                 ...state,
                 editStatus: 'edit'
             }
 
-        case actionTypes['RESET_'.concat(itemRoot)]:
+        case actionTypes[`RESET_${itemRoot}`]:
             return {
                 ...state,
                 editStatus: 'view'
             }
 
-        case actionTypes['RECEIVE_'.concat(itemRoot)]:
-            case actionTypes['RECEIVE_NEW_'.concat(itemRoot)]:
+        case actionTypes[`RECEIVE_${itemRoot}`]:
+        case actionTypes[`RECEIVE_NEW_${itemRoot}`]:
             return {
                 ...state,
                 loading: false,

--- a/src/Service.Host/client/src/reducers/sernosConfig.js
+++ b/src/Service.Host/client/src/reducers/sernosConfig.js
@@ -1,0 +1,10 @@
+﻿import { sernosConfigActionTypes as actionTypes } from '../actions';
+import itemStoreFactory from './reducerFactories/itemStoreFactory';
+
+const defaultState = {
+    loading: false,
+    item: null,
+    editStatus: 'view'
+}
+
+export default itemStoreFactory('SERNOS_CONFIG', actionTypes, defaultState);


### PR DESCRIPTION
what about this for generating re-usable reducers and action types. 
Obviously the exact shape of these things is still in flux a little at the moment and we will also end up with more than one type of factory.