### PR TITLE
Oracle driver tweaks

### DIFF
--- a/src/Persistence.Linnapps/ServiceDbContext.cs
+++ b/src/Persistence.Linnapps/ServiceDbContext.cs
@@ -29,12 +29,11 @@
             var userId = ConfigurationManager.Configuration["DATABASE_USER_ID"];
             var password = ConfigurationManager.Configuration["DATABASE_PASSWORD"];
             var serviceId = ConfigurationManager.Configuration["DATABASE_NAME"];
+            var tz = ConfigurationManager.Configuration["TIMEZONE"];
 
             var dataSource = $"(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST={host})(PORT=1521))(CONNECT_DATA=(SERVICE_NAME={serviceId})(SERVER=dedicated)))";
 
             optionsBuilder.UseOracle($"Data Source={dataSource};User Id={userId};Password={password};");
-
-            // optionsBuilder.UseOracle($"User Id={userId};Password={password}; Data Source=(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST={host})(PORT=1521)))(CONNECT_DATA=(SERVER=DEDICATED)(SERVICE_NAME={serviceId})));");
             base.OnConfiguring(optionsBuilder);
         }
 

--- a/src/Persistence.Linnapps/ServiceDbContext.cs
+++ b/src/Persistence.Linnapps/ServiceDbContext.cs
@@ -29,7 +29,7 @@
             var userId = ConfigurationManager.Configuration["DATABASE_USER_ID"];
             var password = ConfigurationManager.Configuration["DATABASE_PASSWORD"];
             var serviceId = ConfigurationManager.Configuration["DATABASE_NAME"];
-            var tz = ConfigurationManager.Configuration["TIMEZONE"];
+            var timezone = ConfigurationManager.Configuration["TIMEZONE"];
 
             var dataSource = $"(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST={host})(PORT=1521))(CONNECT_DATA=(SERVICE_NAME={serviceId})(SERVER=dedicated)))";
 

--- a/src/Persistence.Linnapps/ServiceDbContext.cs
+++ b/src/Persistence.Linnapps/ServiceDbContext.cs
@@ -29,7 +29,6 @@
             var userId = ConfigurationManager.Configuration["DATABASE_USER_ID"];
             var password = ConfigurationManager.Configuration["DATABASE_PASSWORD"];
             var serviceId = ConfigurationManager.Configuration["DATABASE_NAME"];
-            var timezone = ConfigurationManager.Configuration["TIMEZONE"];
 
             var dataSource = $"(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST={host})(PORT=1521))(CONNECT_DATA=(SERVICE_NAME={serviceId})(SERVER=dedicated)))";
 

--- a/src/Persistence.Linnapps/ServiceDbContext.cs
+++ b/src/Persistence.Linnapps/ServiceDbContext.cs
@@ -29,7 +29,12 @@
             var userId = ConfigurationManager.Configuration["DATABASE_USER_ID"];
             var password = ConfigurationManager.Configuration["DATABASE_PASSWORD"];
             var serviceId = ConfigurationManager.Configuration["DATABASE_NAME"];
-            optionsBuilder.UseOracle($"User Id={userId};Password={password}; Data Source=(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST={host})(PORT=1521)))(CONNECT_DATA=(SERVER=DEDICATED)(SERVICE_NAME={serviceId})));");
+
+            var dataSource = $"(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST={host})(PORT=1521))(CONNECT_DATA=(SERVICE_NAME={serviceId})(SERVER=dedicated)))";
+
+            optionsBuilder.UseOracle($"Data Source={dataSource};User Id={userId};Password={password};");
+
+            // optionsBuilder.UseOracle($"User Id={userId};Password={password}; Data Source=(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST={host})(PORT=1521)))(CONNECT_DATA=(SERVER=DEDICATED)(SERVICE_NAME={serviceId})));");
             base.OnConfiguring(optionsBuilder);
         }
 

--- a/src/Persistence.Linnapps/ServiceDbContext.cs
+++ b/src/Persistence.Linnapps/ServiceDbContext.cs
@@ -29,7 +29,7 @@
             var userId = ConfigurationManager.Configuration["DATABASE_USER_ID"];
             var password = ConfigurationManager.Configuration["DATABASE_PASSWORD"];
             var serviceId = ConfigurationManager.Configuration["DATABASE_NAME"];
-            optionsBuilder.UseOracle($"User Id={userId};Password={password}; Data Source=(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST={host}.linn.co.uk)(PORT=1521)))(CONNECT_DATA=(SERVER=DEDICATED)(SERVICE_NAME={serviceId})));");
+            optionsBuilder.UseOracle($"User Id={userId};Password={password}; Data Source=(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST={host})(PORT=1521)))(CONNECT_DATA=(SERVER=DEDICATED)(SERVICE_NAME={serviceId})));");
             base.OnConfiguring(optionsBuilder);
         }
 

--- a/src/Service.Host/Dockerfile
+++ b/src/Service.Host/Dockerfile
@@ -11,5 +11,6 @@ COPY views/ /app/views/
      
 ENV APP_PATH /app/
 ENV GIT_BRANCH $gitBranch
+ENV TZ UTC
 
 CMD dotnet /app/bin/Linn.Products.Service.Host.dll


### PR DESCRIPTION
allows oracle driver to work by reworking the connection string to give ability to just pass in IP string and also forcing a TZ into the docker of UTC without which you get 

ORA-00604: error occurred at recursive SQL level 1
ORA-01882: timezone region  not found

doesn't look like much but this is 2.5 days worth of pain