### PR TITLE
fix

### DIFF
--- a/src/Service.Host/client/src/components/SaCoreType.js
+++ b/src/Service.Host/client/src/components/SaCoreType.js
@@ -20,8 +20,8 @@ class SaCoreType extends Component {
         };
     }
 
-    static getDerivedStateFromProps(props, state) {
-        if (!state.saCoreType && props.saCoreType) {
+    static getDerivedStateFromProps(props) {
+        if (props.saCoreType) {
             return { saCoreType: props.saCoreType };
         }
 


### PR DESCRIPTION
This bug exists across all the components that use the following:

`static getDerivedStateFromProps(props, state) {
        if (!state.sernosConfig && props.sernosConfig) {
            return { sernosConfig: props.sernosConfig };
        }
        return null;
    }`

It seems that when this function gets called, state can still contain the previous saCoreType object.

The fix proposed here is just to make sure state matches props as soon as the new saCoreType arrives from the fetch regardless of whether there is already an saCoreType in state.

Does this seem sensible? 