### PR TITLE
new initialiseOnMount idea

### DIFF
--- a/src/Service.Host/client/src/containers/common/initialiseOnMount.js
+++ b/src/Service.Host/client/src/containers/common/initialiseOnMount.js
@@ -1,17 +1,15 @@
-﻿import React, { Component } from 'react';
+﻿import React, { useEffect } from 'react';
 
 const initialiseOnMount = ComposedComponent =>
-    class extends Component {
-        componentDidMount() {
-            const { initialise } = this.props;
+    function HOC(props) {
+        const { initialise, itemId } = props;
+        useEffect(() => {
             if (initialise) {
-                initialise(this.props);
+                initialise({ itemId });
             }
-        }
+        }, [initialise, itemId]);
 
-        render() {
-            return <ComposedComponent {...this.props} />;
-        }
+        return <ComposedComponent {...props} />;
     };
 
 export default initialiseOnMount;


### PR DESCRIPTION
**pros:**

- Functional, no more components, no more componentDidMount()!

- Uses the useEffect() hook to initialise components whenever they receive a new initialise function (i.e. on mount) and takes an optional itemId field which can be used to fetch single entity items where necessary.

**cons:** 

- Will need to refactor all the single entity containers to pass a generic itemId as props as opposed to, say for example, the more specific saCoreTypeId fields used in a few of the containers.

- still uses HOCs, which complicate the virtual DOM tree and could confuse debugging? Might be a cleaner way to do this using purely hooks although I'm not sure, haven't come across any example of hooks being used to initialise props like this.

This PR is really just to get a discussion going, not intending to merge it any time soon :)